### PR TITLE
Fix index template not found during build

### DIFF
--- a/userguide/src/main/jbake/jbake.properties
+++ b/userguide/src/main/jbake/jbake.properties
@@ -3,5 +3,6 @@ render.tags=false
 render.sitemap=false
 render.archive=false
 render.feed=false
+render.index=false
 asciidoctor.option.safe=0
 asciidoctor.attributes.export=true


### PR DESCRIPTION
jbake plugin is looking for index file and fail because it cannot find it. Adding render.index property fix the issue

Signed-off-by: tvallin <thibault.vallin@oracle.com>